### PR TITLE
rename event_type field to "name"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Example::
 Running the above example produces the following events::
 
     {
-        "event_type": "navigation.request",
+        "name": "navigation.request",
         "timestamp": ...,
         "context": {
             "user_id": 10938
@@ -55,7 +55,7 @@ Running the above example produces the following events::
         }
     },
     {
-        "event_type": "navigation.request",
+        "name": "navigation.request",
         "timestamp": ...,
         "context": {
             "user_id": 11111,
@@ -66,7 +66,7 @@ Running the above example produces the following events::
         }
     },    
     {
-        "event_type": "navigation.request",
+        "name": "navigation.request",
         "timestamp": ...,
         "context": {
             "user_id": 10938

--- a/doc/user_guide/design.rst
+++ b/doc/user_guide/design.rst
@@ -11,9 +11,9 @@ Interface
 Python
 ------
 
-.. function:: tracker.register(event_type, description, field_descriptions)
+.. function:: tracker.register(name, description, field_descriptions)
 
-:event_type: A unique identification string for this type of event
+:name: A unique identification string for this type of event
 :description: A description of the event and the conditions under which it is emitted
 :field_descriptions: A dictionary mapping field names to a long form description
 
@@ -39,9 +39,9 @@ Example::
         }
     )
 
-.. function:: tracker.emit(event_type, field_values)
+.. function:: tracker.emit(name, field_values)
 
-:event_type: A unique identification string for an event that has already been registered.
+:name: A unique identification string for an event that has already been registered.
 :field_values: A dictionary mapping field names to the value to include in the event.  Note that all values provided must be serializable.
 
 Regardless of previous state or configuration, the data will always be logged, however, in the following conditions will cause a warning to be logged:
@@ -55,7 +55,7 @@ Regardless of previous state or configuration, the data will always be logged, h
 .. function:: tracker.enter_context(name, context, description, field_descriptions)
 
 :context: A dictionary of key-value pairs that will be included in every event emitted after this call.  Values defined in this dictionary will override any previous calls to push_context with maps that contain the same key.
-:event_type: A unique identification string for this type of context.
+:name: A unique identification string for this type of context.
 :description: A clear description of the conditions under which this context is included.
 :field_descriptions: A dictionary mapping field names to a long form description.
 
@@ -68,9 +68,9 @@ Removes the named context from the stack.
 Javascript
 ----------
 
-.. function:: Tracker.emit(event_type, field_values)
+.. function:: Tracker.emit(name, field_values)
 
-:event_type: A unique identification string for an event that has already been registered.
+:name: A unique identification string for an event that has already been registered.
 :field_values: An object mapping field names to the value to include in the event.  Note that all values provided must be serializable.
 
 See the documentation for the Python API.
@@ -151,9 +151,9 @@ Sample Events
 Show Answer::
 
     {
-        "event_type": "edx.problem.show_answer",
+        "name": "edx.problem.show_answer",
         "timestamp": "2013-09-12T12:55:00.12345+00:00",
-        "event_type_id": "10ac28",
+        "name_id": "10ac28",
         "context_type_id": "11bd88",
         "context": {
             "course_id":"",
@@ -208,9 +208,9 @@ Event Schema::
         "description": "An event emitted from the edx platform.",
     
         "properties":{
-            "event_type": {
+            "name": {
                 "type": "string",
-                "id": "http://edx.org/event/event_type",
+                "id": "http://edx.org/event/name",
                 "description": "A unique identifier for this type of event.",
                 "required": true
             },
@@ -220,9 +220,9 @@ Event Schema::
                 "description": "The UTC time the event was emitted in RFC-3339 format.",
                 "required": true
             }
-            "event_type_id": {
+            "name_id": {
                 "type": "string",
-                "id": "http://edx.org/event/event_type_id",
+                "id": "http://edx.org/event/name_id",
                 "description": "A unique reference to the metadata for this event type.",
                 "required": false
             },

--- a/eventtracking/backends/mongodb.py
+++ b/eventtracking/backends/mongodb.py
@@ -81,7 +81,7 @@ class MongoBackend(object):
         # management command or equivalent. There is also an option to
         # run the indexing on the background, without locking.
         self.collection.ensure_index([('time', pymongo.DESCENDING)])
-        self.collection.ensure_index('event_type')
+        self.collection.ensure_index('name')
 
     def send(self, event):
         """Insert the event in to the Mongo collection"""

--- a/eventtracking/tracker.py
+++ b/eventtracking/tracker.py
@@ -51,18 +51,18 @@ class Tracker(object):
         """Gets the backend that was configured with `name`"""
         return self.backends[name]
 
-    def emit(self, event_type=None, data=None):
+    def emit(self, name=None, data=None):
         """
         Emit an event annotated with the UTC time when this function was called.
 
-        `event_type` is a unique identification string for an event that has
+        `name` is a unique identification string for an event that has
             already been registered.
         `data` is a dictionary mapping field names to the value to include in the event.
             Note that all values provided must be serializable.
 
         """
         full_event = {
-            'event_type': event_type or UNKNOWN_EVENT_TYPE,
+            'name': name or UNKNOWN_EVENT_TYPE,
             'timestamp': datetime.now(UTC),
             'data': data or {},
             'context': self.resolve_context()
@@ -134,6 +134,6 @@ def get_tracker(name=DEFAULT_TRACKER_NAME):
     return TRACKERS[name]
 
 
-def emit(event_type=None, data=None):
+def emit(name=None, data=None):
     """Calls `Tracker.emit` on the default global tracker"""
-    return get_tracker().emit(event_type=event_type, data=data)
+    return get_tracker().emit(name=name, data=data)


### PR DESCRIPTION
I didn't want to use "type" since that is a reserved keyword in python.

Reviewers: @rocha
