### PR TITLE
Add an OEP-2 compliant openedx.yaml file

### DIFF
--- a/eventtracking/backends/tests/test_logger.py
+++ b/eventtracking/backends/tests/test_logger.py
@@ -4,11 +4,11 @@ from __future__ import absolute_import
 
 import json
 import datetime
-import pytz
-
 from unittest import TestCase
+
 from mock import patch
 from mock import sentinel
+import pytz
 
 from eventtracking.backends.logger import LoggerBackend
 

--- a/eventtracking/django/__init__.py
+++ b/eventtracking/django/__init__.py
@@ -108,7 +108,7 @@ class DjangoTracker(Tracker):
                 for key, value in node.iteritems():
                     result[key] = self.instantiate_objects(value)
         elif isinstance(node, list):
-            result = []
+            result = []  # pylint: disable=redefined-variable-type
             for child in node:
                 result.append(self.instantiate_objects(child))
 

--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,0 +1,5 @@
+# This file describes this Open edX repo, as described in OEP-2:
+# http://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html#specification
+
+oeps: {}
+owner: MUST FILL IN OWNER

--- a/openedx.yaml
+++ b/openedx.yaml
@@ -2,4 +2,4 @@
 # http://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html#specification
 
 oeps: {}
-owner: MUST FILL IN OWNER
+owner: edx/analytics


### PR DESCRIPTION

This adds an `openedx.yaml` file, as described by OEP-2:
http://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html

The data in this file was transformed from the contents of
edx/repo-tools-data:repos.yaml
