### PR TITLE
Update pymongo dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django >= 1.8, < 1.9
-pymongo==2.4.1
+pymongo>=2.7.2,<4.0.0
 pytz

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='event-tracking',
-    version='0.2.1',
+    version='0.2.2',
     packages=find_packages(),
     include_package_data=True,
     license='AGPLv3 License',


### PR DESCRIPTION
Update the requirement on pymongo to be more flexible, so that this library can be consumed by edx-platform which currently requires 2.9.1.

@mulby @jcdyer please review.