### PR TITLE
[BD-18] Use pytest instead of nosetest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,4 @@
 [run]
 branch = True
 include = eventtracking*
+omit = */*performance*, */*integration*

--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,13 @@ test.setup: ## install dependencies for running tests
 test: test.unit test.integration test.performance ## run all tests
 
 test.unit: test.setup ## run unit tests
-	nosetests --cover-erase --with-coverage --cover-branches -A 'not integration and not performance' --cover-min-percentage=95 --cover-package=eventtracking
+	pytest --cov-report=html --cov-report term-missing  --cov-branch -k 'not integration and not performance' --cov-fail-under=95 --cov=eventtracking
 
 test.integration: test.setup ## run integration tests
-	nosetests --verbose --nocapture -a 'integration'
+	pytest --verbose -s -k 'integration'
 
 test.performance: test.setup ## run performance tests
-	nosetests --verbose --nocapture -a 'performance'
+	pytest --verbose -s -k 'performance'
 
 style: ## run pycodestyle on the code
 	pycodestyle eventtracking

--- a/eventtracking/django/tests/settings.py
+++ b/eventtracking/django/tests/settings.py
@@ -18,11 +18,8 @@ MIDDLEWARE = (
 )
 
 INSTALLED_APPS = [
-    'django_nose',
     'eventtracking.django'
 ]
-
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 EVENT_TRACKING_ENABLED = True
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,8 +4,8 @@
 #
 #    make upgrade
 #
-django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in
 pymongo==3.10.1           # via -r requirements/base.in
 pytz==2020.1              # via -r requirements/base.in, django
-six==1.14.0               # via -r requirements/base.in
+six==1.15.0               # via -r requirements/base.in
 sqlparse==0.3.1           # via django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,6 +14,3 @@ django<2.3
 
 # mock version 4.0.0 drops support for python 3.5
 mock<4.0.0
-
-
-nose>=1.3.7,<2.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,49 +5,52 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via sphinx
-appdirs==1.4.3            # via -r requirements/travis.txt, virtualenv
+appdirs==1.4.4            # via -r requirements/travis.txt, virtualenv
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
+attrs==19.3.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
-certifi==2020.4.5.1       # via -r requirements/travis.txt, requests
+certifi==2020.6.20        # via -r requirements/travis.txt, requests
 chardet==3.0.4            # via -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/test.txt, click-log, edx-lint, pip-tools
-codecov==2.0.22           # via -r requirements/travis.txt
-coverage==5.1             # via -r requirements/test.txt, -r requirements/travis.txt, codecov
-distlib==0.3.0            # via -r requirements/travis.txt, virtualenv
-django-nose==1.4.6        # via -r requirements/test.txt
-django==2.2.12            # via -c requirements/constraints.txt, -r requirements/test.txt
+codecov==2.1.7            # via -r requirements/travis.txt
+coverage==5.1             # via -r requirements/test.txt, -r requirements/travis.txt, codecov, pytest-cov
+distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/test.txt
 docutils==0.16            # via sphinx
-edx-lint==1.4.1           # via -r requirements/dev.in, -r requirements/test.txt
+edx-lint==1.5.0           # via -r requirements/dev.in, -r requirements/test.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
-idna==2.9                 # via -r requirements/travis.txt, requests
+idna==2.10                # via -r requirements/travis.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.6.0  # via -r requirements/travis.txt, importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via -r requirements/travis.txt, virtualenv
+importlib-metadata==1.7.0  # via -r requirements/test.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
+importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 isort==4.3.21             # via -r requirements/test.txt, pylint
 jinja2==2.11.2            # via sphinx
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
-nose==1.3.7               # via -c requirements/constraints.txt, -r requirements/test.txt, django-nose
-packaging==20.3           # via -r requirements/travis.txt, sphinx, tox
-pip-tools==5.1.2          # via -r requirements/dev.in, -r requirements/pip-tools.txt
-pluggy==0.13.1            # via -r requirements/travis.txt, tox
-py==1.8.1                 # via -r requirements/travis.txt, tox
-pycodestyle==2.5.0        # via -r requirements/dev.in, -r requirements/test.txt
+more-itertools==8.4.0     # via -r requirements/test.txt, pytest
+packaging==20.4           # via -r requirements/test.txt, -r requirements/travis.txt, pytest, sphinx, tox
+pathlib2==2.3.5           # via -r requirements/test.txt, pytest
+pip-tools==5.2.1          # via -r requirements/dev.in, -r requirements/pip-tools.txt
+pluggy==0.13.1            # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
+py==1.9.0                 # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
+pycodestyle==2.6.0        # via -r requirements/dev.in, -r requirements/test.txt
 pygments==2.6.1           # via sphinx
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
-pylint==2.4.2             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/test.txt
-pyparsing==2.4.7          # via -r requirements/travis.txt, packaging
+pyparsing==2.4.7          # via -r requirements/test.txt, -r requirements/travis.txt, packaging
+pytest-cov==2.10.0        # via -r requirements/test.txt
+pytest==5.4.3             # via -r requirements/test.txt, pytest-cov
 pytz==2020.1              # via -r requirements/test.txt, babel, django
-requests==2.23.0          # via -r requirements/travis.txt, codecov, sphinx
-six==1.14.0               # via -r requirements/pip-tools.txt, -r requirements/test.txt, -r requirements/travis.txt, astroid, edx-lint, mock, packaging, pip-tools, tox, virtualenv
+requests==2.24.0          # via -r requirements/travis.txt, codecov, sphinx
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/test.txt, -r requirements/travis.txt, astroid, edx-lint, mock, packaging, pathlib2, pip-tools, tox, virtualenv
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.0.3             # via -r requirements/dev.in
+sphinx==3.1.1             # via -r requirements/dev.in
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -55,14 +58,15 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.3.1           # via -r requirements/test.txt, django
-toml==0.10.0              # via -r requirements/travis.txt, tox
-tox-battery==0.5.2        # via -r requirements/travis.txt
-tox==3.15.0               # via -r requirements/dev.in, -r requirements/travis.txt, tox-battery
+toml==0.10.1              # via -r requirements/travis.txt, tox
+tox-battery==0.6.1        # via -r requirements/travis.txt
+tox==3.16.1               # via -r requirements/dev.in, -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 urllib3==1.25.9           # via -r requirements/travis.txt, requests
-virtualenv==20.0.20       # via -r requirements/travis.txt, tox
+virtualenv==20.0.25       # via -r requirements/travis.txt, tox
+wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
-zipp==1.2.0               # via -r requirements/travis.txt, importlib-metadata, importlib-resources
+zipp==1.2.0               # via -r requirements/test.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,8 +5,8 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.1.2          # via -r requirements/pip-tools.in
-six==1.14.0               # via pip-tools
+pip-tools==5.2.1          # via -r requirements/pip-tools.in
+six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -5,9 +5,6 @@
 -r base.txt               # Core dependencies for this package
 
 edx-lint
-coverage
 pycodestyle
-django_nose
 mock
-nose
-
+pytest-cov

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,24 +5,34 @@
 #    make upgrade
 #
 astroid==2.3.3            # via pylint, pylint-celery
+attrs==19.3.0             # via pytest
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
-coverage==5.1             # via -r requirements/test.in
-django-nose==1.4.6        # via -r requirements/test.in
-edx-lint==1.4.1           # via -r requirements/test.in
+coverage==5.1             # via pytest-cov
+edx-lint==1.5.0           # via -r requirements/test.in
+importlib-metadata==1.7.0  # via pluggy, pytest
 isort==4.3.21             # via pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
-nose==1.3.7               # via -c requirements/constraints.txt, -r requirements/test.in, django-nose
-pycodestyle==2.5.0        # via -r requirements/test.in
+more-itertools==8.4.0     # via pytest
+packaging==20.4           # via pytest
+pathlib2==2.3.5           # via pytest
+pluggy==0.13.1            # via pytest
+py==1.9.0                 # via pytest
+pycodestyle==2.6.0        # via -r requirements/test.in
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/base.txt
+pyparsing==2.4.7          # via packaging
+pytest-cov==2.10.0        # via -r requirements/test.in
+pytest==5.4.3             # via pytest-cov
 pytz==2020.1              # via -r requirements/base.txt, django
-six==1.14.0               # via -r requirements/base.txt, astroid, edx-lint, mock
+six==1.15.0               # via -r requirements/base.txt, astroid, edx-lint, mock, packaging, pathlib2
 sqlparse==0.3.1           # via -r requirements/base.txt, django
 typed-ast==1.4.1          # via astroid
+wcwidth==0.2.5            # via pytest
 wrapt==1.11.2             # via astroid
+zipp==1.2.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,25 +4,25 @@
 #
 #    make upgrade
 #
-appdirs==1.4.3            # via virtualenv
-certifi==2020.4.5.1       # via requests
+appdirs==1.4.4            # via virtualenv
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
-codecov==2.0.22           # via -r requirements/travis.in
+codecov==2.1.7            # via -r requirements/travis.in
 coverage==5.1             # via codecov
-distlib==0.3.0            # via virtualenv
+distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-idna==2.9                 # via requests
-importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via virtualenv
-packaging==20.3           # via tox
+idna==2.10                # via requests
+importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-resources==3.0.0  # via virtualenv
+packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
-py==1.8.1                 # via tox
+py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
-requests==2.23.0          # via codecov
-six==1.14.0               # via packaging, tox, virtualenv
-toml==0.10.0              # via tox
-tox-battery==0.5.2        # via -r requirements/travis.in
-tox==3.15.0               # via -r requirements/travis.in, tox-battery
+requests==2.24.0          # via codecov
+six==1.15.0               # via packaging, tox, virtualenv
+toml==0.10.1              # via tox
+tox-battery==0.6.1        # via -r requirements/travis.in
+tox==3.16.1               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.9           # via requests
-virtualenv==20.0.20       # via tox
+virtualenv==20.0.25       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
 commands =
     django22: pip install 'Django>=2.2,<2.3'
     django30: pip install 'Django>=3.0,<3.1'
-    nosetests --cover-erase --with-coverage --cover-branches -A 'not integration and not performance' --cover-min-percentage=95 --cover-package=eventtracking
-    nosetests --verbose --nocapture -a 'integration'
+    pytest --cov-report=html --cov-report term-missing --cov-branch -k 'not integration and not performance' --cov-fail-under=95 --cov=eventtracking
+    pytest --verbose -s -k 'integration'
     pycodestyle --config=setup.cfg eventtracking setup.py
     pylint --rcfile=pylintrc eventtracking setup.py


### PR DESCRIPTION
### PR description
Switch from `nose` to pytest for running the unit tests.

- Update scripts in the Makefile accordingly
- Update tox.ini file accordingly
- Update requirements file (ran `make upgrade` command using python 3.5)
- Update `.coveragerc` file to exclude performance and integration tests from the coverage report.


After making all these changes and running the `make test.unit` command, we get the following coverage report:

```
---------- coverage: platform darwin, python 3.8.0-final-0 -----------
Name                                               Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------------------------------------------
eventtracking/__init__.py                              0      0      0      0   100%
eventtracking/backends/__init__.py                     0      0      0      0   100%
eventtracking/backends/logger.py                      28      0      8      0   100%
eventtracking/backends/mongodb.py                     34      0      2      0   100%
eventtracking/backends/routing.py                     50      0     22      0   100%
eventtracking/backends/segment.py                     42      0     22      0   100%
eventtracking/backends/tests/__init__.py              37     19      4      0    44%   19-20, 24, 54-58, 66-78
eventtracking/backends/tests/test_logger.py           57      0      2      0   100%
eventtracking/backends/tests/test_mongodb.py          34      0      0      0   100%
eventtracking/backends/tests/test_routing.py         162      1     26      0    99%   232
eventtracking/backends/tests/test_segment.py          70      0      0      0   100%
eventtracking/django/__init__.py                      53      0     12      0   100%
eventtracking/django/apps.py                           5      5      0      0     0%   4-15
eventtracking/django/tests/__init__.py                 0      0      0      0   100%
eventtracking/django/tests/settings.py                 8      0      0      0   100%
eventtracking/django/tests/test_configuration.py     114      2      0      0    98%   259, 269
eventtracking/locator.py                              17      0      4      0   100%
eventtracking/processors/__init__.py                   0      0      0      0   100%
eventtracking/processors/exceptions.py                 1      0      0      0   100%
eventtracking/processors/tests/__init__.py             0      0      0      0   100%
eventtracking/processors/tests/test_whitelist.py      48      0      0      0   100%
eventtracking/processors/whitelist.py                 15      0      4      0   100%
eventtracking/tests/__init__.py                        0      0      0      0   100%
eventtracking/tests/test_locator.py                   28      0      0      0   100%
eventtracking/tests/test_track.py                     74      1      6      1    98%   48, 70->73
eventtracking/tracker.py                              50      0      2      0   100%
----------------------------------------------------------------------------------------------
TOTAL                                                927     28    114      1    97%
Coverage HTML written to dir htmlcov

Required test coverage of 95% reached. Total coverage: 96.83%
```