### PR TITLE
Import DjangoTracker as a part the init for django module.

### DIFF
--- a/eventtracking/django/__init__.py
+++ b/eventtracking/django/__init__.py
@@ -1,4 +1,6 @@
 """
 Event tracking django app.
 """
+from .django_tracker import DjangoTracker
+
 default_app_config = 'eventtracking.django.apps.EventTrackingConfig'


### PR DESCRIPTION
We moved the DjangoTracker out of the `__init__.py` file but we can still import
to not break backwards compatibility.

@danialmalik take a look at this, I realized after I merged that we can just do this to maintain compatibility.