### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,5 +186,5 @@ You can discuss this code on the `edx-code Google Group`__ or in the
 
 __ https://groups.google.com/forum/#!forum/edx-code
 
-.. |build-status| image:: https://api.travis-ci.org/edx/event-tracking.png?branch=master
-   :target: https://travis-ci.org/edx/event-tracking
+.. |build-status| image:: https://api.travis-ci.com/edx/event-tracking.svg?branch=master
+   :target: https://travis-ci.com/edx/event-tracking


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089