### PR TITLE
Adding celery for multiple versions in tox.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@
 language: python
 
 python:
-  - 3.5
   - 3.8
 
 env:
-  - TOXENV=django22
+  - TOXENV=celery44-django22
+  - TOXENV=celery50-django22
 
 install:
   - make test.setup install
@@ -26,3 +26,4 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
+    python: 3.8

--- a/Makefile
+++ b/Makefile
@@ -68,5 +68,19 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip-compile --upgrade -o requirements/travis.txt requirements/travis.in
 	pip-compile --upgrade -o requirements/dev.txt requirements/dev.in
 	# Let tox control the Django version for tests
-	sed '/^[dD]jango==/d' requirements/test.txt > requirements/test.tmp
-	mv requirements/test.tmp requirements/test.txt
+	grep -e "^amqp==\|^anyjson==\|^billiard==\|^celery==\|^kombu==\|^click-didyoumean==\|^click-repl==\|^click==\|^prompt-toolkit==\|^vine==" requirements/base.txt > requirements/celery44.txt
+	sed -i.tmp '/^[d|D]jango==/d' requirements/test.txt
+	sed -i.tmp '/^djangorestframework==/d' requirements/test.txt
+	sed -i.tmp '/^amqp==/d' requirements/test.txt
+	sed -i.tmp '/^anyjson==/d' requirements/test.txt
+	sed -i.tmp '/^billiard==/d' requirements/test.txt
+	sed -i.tmp '/^celery==/d' requirements/test.txt
+	sed -i.tmp '/^kombu==/d' requirements/test.txt
+	sed -i.tmp '/^click-didyoumean==/d' requirements/test.txt
+	sed -i.tmp '/^click-repl==/d' requirements/test.txt
+	sed -i.tmp '/^click==/d' requirements/test.txt
+	sed -i.tmp '/^click==/d' requirements/test.txt
+	sed -i.tmp '/^prompt-toolkit==/d' requirements/test.txt
+	sed -i.tmp '/^vine==/d' requirements/test.txt
+	rm requirements/test.txt.tmp
+

--- a/eventtracking/tasks.py
+++ b/eventtracking/tasks.py
@@ -4,7 +4,7 @@ Celery tasks
 import json
 
 from celery.utils.log import get_task_logger
-from celery import task
+from celery import shared_task
 
 from eventtracking.tracker import get_tracker
 from eventtracking.processors.exceptions import EventEmissionExit
@@ -13,7 +13,7 @@ from eventtracking.processors.exceptions import EventEmissionExit
 logger = get_task_logger(__name__)
 
 
-@task(name='eventtracking.tasks.send_event')
+@shared_task(name='eventtracking.tasks.send_event')
 def send_event(backend_name, json_event):
     """
     Send event to configured backends asynchronously.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,11 +6,11 @@
 #
 amqp==2.6.1               # via kombu
 billiard==3.6.3.0         # via celery
-celery==4.4.7             # via -r requirements/base.in
-django==2.2.15            # via -c requirements/constraints.txt, -r requirements/base.in
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.in
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in
 kombu==4.6.11             # via celery
-pymongo==3.11.0           # via -r requirements/base.in
-pytz==2020.1              # via -r requirements/base.in, celery, django
+pymongo==3.11.2           # via -r requirements/base.in
+pytz==2020.4              # via -r requirements/base.in, celery, django
 six==1.15.0               # via -r requirements/base.in
-sqlparse==0.3.1           # via django
+sqlparse==0.4.1           # via django
 vine==1.3.0               # via amqp, celery

--- a/requirements/celery44.txt
+++ b/requirements/celery44.txt
@@ -1,0 +1,5 @@
+amqp==2.6.1               # via kombu
+billiard==3.6.3.0         # via celery
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/base.in
+kombu==4.6.11             # via celery
+vine==1.3.0               # via amqp, celery

--- a/requirements/celery50.txt
+++ b/requirements/celery50.txt
@@ -1,0 +1,9 @@
+amqp==5.0.2               # via kombu
+billiard==3.6.3.0         # via celery
+celery==5.0.2             # via -c requirements/constraints.txt, -r requirements/base.in
+click-didyoumean==0.0.3   # via celery
+click-repl==0.1.6         # via celery
+click==7.1.2              # via celery, click-didyoumean, click-repl
+kombu==5.0.2              # via celery
+prompt-toolkit==3.0.8     # via click-repl
+vine==5.0.0               # via amqp, celery

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,3 +14,7 @@ django<2.3
 
 # mock version 4.0.0 drops support for python 3.5
 mock<4.0.0
+
+
+# maintaining the production version.
+celery<5.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,25 +8,25 @@ alabaster==0.7.12         # via sphinx
 amqp==2.6.1               # via -r requirements/test.txt, kombu
 appdirs==1.4.4            # via -r requirements/travis.txt, virtualenv
 astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
-attrs==20.1.0             # via -r requirements/test.txt, pytest
-babel==2.8.0              # via sphinx
+attrs==20.3.0             # via -r requirements/test.txt, pytest
+babel==2.9.0              # via sphinx
 billiard==3.6.3.0         # via -r requirements/test.txt, celery
-celery==4.4.7             # via -r requirements/test.txt
-certifi==2020.6.20        # via -r requirements/travis.txt, requests
+celery==4.4.7             # via -c requirements/constraints.txt, -r requirements/test.txt
+certifi==2020.12.5        # via -r requirements/travis.txt, requests
 chardet==3.0.4            # via -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/test.txt, click-log, edx-lint, pip-tools
-codecov==2.1.9            # via -r requirements/travis.txt
-coverage==5.2.1           # via -r requirements/test.txt, -r requirements/travis.txt, codecov, pytest-cov
+codecov==2.1.10           # via -r requirements/travis.txt
+coverage==5.3             # via -r requirements/test.txt, -r requirements/travis.txt, codecov, pytest-cov
 ddt==1.4.1                # via -r requirements/test.txt
 distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
-django==2.2.15            # via -c requirements/constraints.txt, -r requirements/test.txt
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/test.txt
 docutils==0.16            # via sphinx
 edx-lint==1.5.2           # via -r requirements/dev.in, -r requirements/test.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 idna==2.10                # via -r requirements/travis.txt, requests
 imagesize==1.2.0          # via sphinx
-iniconfig==1.0.1          # via -r requirements/test.txt, pytest
+iniconfig==1.1.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/test.txt, pylint
 jinja2==2.11.2            # via sphinx
 kombu==4.6.11             # via -r requirements/test.txt, celery
@@ -34,39 +34,38 @@ lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
-more-itertools==8.4.0     # via -r requirements/test.txt, pytest
-packaging==20.4           # via -r requirements/test.txt, -r requirements/travis.txt, pytest, sphinx, tox
-pip-tools==5.3.1          # via -r requirements/dev.in, -r requirements/pip-tools.txt
+packaging==20.7           # via -r requirements/test.txt, -r requirements/travis.txt, pytest, sphinx, tox
+pip-tools==5.4.0          # via -r requirements/dev.in, -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
 py==1.9.0                 # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/dev.in, -r requirements/test.txt
-pygments==2.6.1           # via sphinx
+pygments==2.7.3           # via sphinx
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
 pylint==2.4.4             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.11.0           # via -r requirements/test.txt
+pymongo==3.11.2           # via -r requirements/test.txt
 pyparsing==2.4.7          # via -r requirements/test.txt, -r requirements/travis.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.txt
-pytest==6.0.1             # via -r requirements/test.txt, pytest-cov
-pytz==2020.1              # via -r requirements/test.txt, babel, celery, django
-requests==2.24.0          # via -r requirements/travis.txt, codecov, sphinx
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/test.txt, -r requirements/travis.txt, astroid, edx-lint, mock, packaging, pip-tools, tox, virtualenv
+pytest==6.1.2             # via -r requirements/test.txt, pytest-cov
+pytz==2020.4              # via -r requirements/test.txt, babel, celery, django
+requests==2.25.0          # via -r requirements/travis.txt, codecov, sphinx
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/test.txt, -r requirements/travis.txt, astroid, edx-lint, mock, pip-tools, tox, virtualenv
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.2.1             # via -r requirements/dev.in
+sphinx==3.3.1             # via -r requirements/dev.in
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
-sqlparse==0.3.1           # via -r requirements/test.txt, django
-toml==0.10.1              # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
+sqlparse==0.4.1           # via -r requirements/test.txt, django
+toml==0.10.2              # via -r requirements/test.txt, -r requirements/travis.txt, pytest, tox
 tox-battery==0.6.1        # via -r requirements/travis.txt
-tox==3.19.0               # via -r requirements/dev.in, -r requirements/travis.txt, tox-battery
-urllib3==1.25.10          # via -r requirements/travis.txt, requests
+tox==3.20.1               # via -r requirements/dev.in, -r requirements/travis.txt, tox-battery
+urllib3==1.26.2           # via -r requirements/travis.txt, requests
 vine==1.3.0               # via -r requirements/test.txt, amqp, celery
-virtualenv==20.0.31       # via -r requirements/travis.txt, tox
+virtualenv==20.2.2        # via -r requirements/travis.txt, tox
 wrapt==1.11.2             # via -r requirements/test.txt, astroid
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.3.1          # via -r requirements/pip-tools.in
+pip-tools==5.4.0          # via -r requirements/pip-tools.in
 six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,24 +4,18 @@
 #
 #    make upgrade
 #
-amqp==2.6.1               # via -r requirements/base.txt, kombu
 astroid==2.3.3            # via pylint, pylint-celery
-attrs==20.1.0             # via pytest
-billiard==3.6.3.0         # via -r requirements/base.txt, celery
-celery==4.4.7             # via -r requirements/base.txt
+attrs==20.3.0             # via pytest
 click-log==0.3.2          # via edx-lint
-click==7.1.2              # via click-log, edx-lint
-coverage==5.2.1           # via pytest-cov
+coverage==5.3             # via pytest-cov
 ddt==1.4.1                # via -r requirements/test.in
 edx-lint==1.5.2           # via -r requirements/test.in
-iniconfig==1.0.1          # via pytest
+iniconfig==1.1.1          # via pytest
 isort==4.3.21             # via pylint
-kombu==4.6.11             # via -r requirements/base.txt, celery
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
-more-itertools==8.4.0     # via pytest
-packaging==20.4           # via pytest
+packaging==20.7           # via pytest
 pluggy==0.13.1            # via pytest
 py==1.9.0                 # via pytest
 pycodestyle==2.6.0        # via -r requirements/test.in
@@ -29,13 +23,12 @@ pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.11.0           # via -r requirements/base.txt
+pymongo==3.11.2           # via -r requirements/base.txt
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.1        # via -r requirements/test.in
-pytest==6.0.1             # via pytest-cov
-pytz==2020.1              # via -r requirements/base.txt, celery, django
-six==1.15.0               # via -r requirements/base.txt, astroid, edx-lint, mock, packaging
-sqlparse==0.3.1           # via -r requirements/base.txt, django
-toml==0.10.1              # via pytest
-vine==1.3.0               # via -r requirements/base.txt, amqp, celery
+pytest==6.1.2             # via pytest-cov
+pytz==2020.4              # via -r requirements/base.txt, celery, django
+six==1.15.0               # via -r requirements/base.txt, astroid, edx-lint, mock
+sqlparse==0.4.1           # via -r requirements/base.txt, django
+toml==0.10.2              # via pytest
 wrapt==1.11.2             # via astroid

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -5,21 +5,21 @@
 #    make upgrade
 #
 appdirs==1.4.4            # via virtualenv
-certifi==2020.6.20        # via requests
+certifi==2020.12.5        # via requests
 chardet==3.0.4            # via requests
-codecov==2.1.9            # via -r requirements/travis.in
-coverage==5.2.1           # via codecov
+codecov==2.1.10           # via -r requirements/travis.in
+coverage==5.3             # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-packaging==20.4           # via tox
+packaging==20.7           # via tox
 pluggy==0.13.1            # via tox
 py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
-requests==2.24.0          # via codecov
-six==1.15.0               # via packaging, tox, virtualenv
-toml==0.10.1              # via tox
+requests==2.25.0          # via codecov
+six==1.15.0               # via tox, virtualenv
+toml==0.10.2              # via tox
 tox-battery==0.6.1        # via -r requirements/travis.in
-tox==3.19.0               # via -r requirements/travis.in, tox-battery
-urllib3==1.25.10          # via requests
-virtualenv==20.0.31       # via tox
+tox==3.20.1               # via -r requirements/travis.in, tox-battery
+urllib3==1.26.2           # via requests
+virtualenv==20.2.2        # via tox

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ REQUIREMENTS = load_requirements('requirements/base.in')
 
 setup(
     name='event-tracking',
-    version='1.0.0',
+    version='1.0.1',
     packages=find_packages(),
     include_package_data=True,
     license='AGPLv3 License',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35-django22,py38-django{22,30}
+envlist = py38-celery{44,50}-django{22,30}
 
 [testenv]
 setenv =
@@ -7,6 +7,8 @@ setenv =
     PYTHONPATH = {toxinidir}
 
 deps =
+    celery44: -r{toxinidir}/requirements/celery44.txt
+    celery50: -r{toxinidir}/requirements/celery50.txt
     -r{toxinidir}/requirements/test.txt
 
 # These are the equivalent of 'make ci'.


### PR DESCRIPTION
- Adding celery 5.0 testing using tox.
- Drop py3.5 testing
- execute make upgrade using py38 with celery<5 constraint.
- replaced task decorator with shared decorator.

In next PR I will execute the make upgrade with celery==5.0.2

I am making a sandbox to do some testing using this branch https://github.com/edx/edx-platform/pull/25835


Steps to enable event on sandbox.

1. Copy this config in lms/env/common.py 
https://gist.github.com/awais786/56b078e81b3879b63b419228f8620971

2.  https://webhook.site/  go here and make new URL.

3. https://awais786.sandbox.edx.org/admin/event_routing_backends/routerconfiguration/add/

backend name = `caliper`
values = `[{"match_params":{"context.host":"awais786.sandbox.edx.org"},"router_type":"AUTH_HEADERS","host_configurations":{"url":"https://webhook.site/0b645ad4-82f2-455c-8cf3-42c07b14c507"}}]`

4. sudo /edx/bin/supervisorctl restart all
5. Now register new user and enroll celery flower will show the tasks and these tasks will appear on webhooksite as well.




