### PR TITLE
feat: single celery task for sending event only

### DIFF
--- a/eventtracking/backends/tests/test_async_routing.py
+++ b/eventtracking/backends/tests/test_async_routing.py
@@ -1,7 +1,6 @@
 """
 Test the async routing backend.
 """
-import json
 from unittest import TestCase
 
 from unittest.mock import sentinel, patch
@@ -25,15 +24,9 @@ class TestAsyncRoutingBackend(TestCase):
             'session': '0000'
         }
 
-    @patch('eventtracking.backends.async_routing.json.dumps', side_effect=ValueError)
-    @patch('eventtracking.backends.async_routing.send_event')
-    def test_json_encoding_error(self, mocked_send_event, _):
-        backend = AsyncRoutingBackend()
-        backend.send(self.sample_event)
-        mocked_send_event.assert_not_called()
-
     @patch('eventtracking.backends.async_routing.send_event')
     def test_successful_event_send(self, mocked_send_event):
         backend = AsyncRoutingBackend(backend_name='test')
+        processed_event = backend.process_event(self.sample_event)
         backend.send(self.sample_event)
-        mocked_send_event.delay.assert_called_once_with('test', json.dumps(self.sample_event))
+        mocked_send_event.delay.assert_called_once_with('test', processed_event)

--- a/eventtracking/tasks.py
+++ b/eventtracking/tasks.py
@@ -1,25 +1,22 @@
 """
 Celery tasks
 """
-import json
 
 from celery.utils.log import get_task_logger
 from celery import shared_task
-
 from eventtracking.tracker import get_tracker
-from eventtracking.processors.exceptions import EventEmissionExit
-
 
 logger = get_task_logger(__name__)
+# Maximum number of retries before giving up on rounting event
+MAX_RETRIES = 3
+# Number of seconds after task is retried
+COUNTDOWN = 30
 
 
-@shared_task(name='eventtracking.tasks.send_event')
-def send_event(backend_name, json_event):
+@shared_task(bind=True)
+def send_event(self, backend_name, processed_event):
     """
     Send event to configured top-level backend asynchronously.
-
-    Load the backend with name `backend_name` and use it to process and send
-    the event to configured nested backends.
 
     WARNING: Do not use this task directly! It is intended for use
     only by the AsyncRoutingBackend, since it is implemented with the
@@ -29,28 +26,17 @@ def send_event(backend_name, json_event):
     - That the named backend is a RoutingBackend (or descendent)
 
     Arguments:
-        backend_name (str):    name of the backend to use
-        json_event (str)  :    JSON encoded event
+        self (dict): task
+        backend_name (str):  name of the backend to use
+        processed_event (dict): Processed event dict
     """
-    event = json.loads(json_event)
-    tracker = get_tracker()
-    backend = tracker.backends[backend_name]
-
-    # Reimplements `RoutingBackend.send()` logic so that the event
-    # doesn't get sent via celery again.
-    #
-    # `AsyncRoutingBackend.send()` should probably be changed to add
-    # an `immediate=False` kwarg and call the super method to perform
-    # immediate processing when `immediate=True`.
-
     try:
-        processed_event = backend.process_event(event)
-        logger.info('Successfully processed event "{}"'.format(event['name']))
-
-    except EventEmissionExit:
-        logger.info('[EventEmissionExit] skipping event {}'.format(event['name']))
-        return
-
-    for name, backend in backend.backends.items():
-        logger.info('Sending processed event "{}" to backend {}.'.format(event['name'], name))
-        backend.send(processed_event.copy())
+        tracker = get_tracker()
+        backend = tracker.backends[backend_name]
+        backend.send_to_backends(processed_event.copy())
+    except Exception as exc:
+        logger.exception(
+            '[send_event] Failed to send event [%s] with backend [%s], [%s]',
+            processed_event['name'], backend_name, exc
+        )
+        raise self.retry(exc=exc, countdown=COUNTDOWN, max_retries=MAX_RETRIES)


### PR DESCRIPTION
In this PR we have update async routing process. We have taken out event processing from celery task and implemented it before send_event. In celery task we are sent event to backends only