### PR TITLE
feat: Skip Retry Celery Tasks on known exceptions

### DIFF
--- a/eventtracking/processors/exceptions.py
+++ b/eventtracking/processors/exceptions.py
@@ -7,3 +7,17 @@ class EventEmissionExit(Exception):
 
     This should only be raised by processors.
     """
+
+
+class NoTransformerImplemented(Exception):
+    """
+    Raise this exception when there is no transformer implemented
+    for an event.
+    """
+
+
+class NoBackendEnabled(Exception):
+    """
+    Raise this exception when there is no backend enabled
+    for an event.
+    """

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ REQUIREMENTS = load_requirements('requirements/base.in')
 
 setup(
     name='event-tracking',
-    version='1.1.0',
+    version='1.1.1',
     packages=find_packages(),
     include_package_data=True,
     license='AGPLv3 License',


### PR DESCRIPTION
To avoid retrying celery task when event does not have corresponding transformer or backend enabled we have defined custom exceptions. These exceptions are raised from event-routing-backends.