### PR TITLE
refactor: change log level from exception to info for NoTransformerImplemented and NoBackendEnabled exceptions

### DIFF
--- a/eventtracking/backends/routing.py
+++ b/eventtracking/backends/routing.py
@@ -5,7 +5,11 @@ import logging
 from collections import OrderedDict
 from copy import deepcopy
 
-from eventtracking.processors.exceptions import EventEmissionExit
+from eventtracking.processors.exceptions import (
+    EventEmissionExit,
+    NoBackendEnabled,
+    NoTransformerImplemented,
+)
 
 
 LOG = logging.getLogger(__name__)
@@ -131,6 +135,11 @@ class RoutingBackend:
         for name, backend in self.backends.items():
             try:
                 backend.send(event)
+            except (NoTransformerImplemented, NoBackendEnabled) as exc:
+                LOG.info(
+                    '[send_to_backends] Failed to send event [%s] with backend [%s], [%s]',
+                    event, backend, repr(exc)
+                )
             except Exception:  # pylint: disable=broad-except
                 LOG.exception(
                     'Unable to send event to backend: %s', name

--- a/eventtracking/tasks.py
+++ b/eventtracking/tasks.py
@@ -5,8 +5,10 @@ Celery tasks
 from celery.utils.log import get_task_logger
 from celery import shared_task
 from eventtracking.tracker import get_tracker
-from eventtracking.processors.exceptions import NoTransformerImplemented
-from eventtracking.processors.exceptions import NoBackendEnabled
+from eventtracking.processors.exceptions import (
+    NoBackendEnabled,
+    NoTransformerImplemented,
+)
 
 logger = get_task_logger(__name__)
 # Maximum number of retries before giving up on rounting event
@@ -38,7 +40,7 @@ def send_event(self, backend_name, processed_event):
         backend.send_to_backends(processed_event.copy())
 
     except (NoTransformerImplemented, NoBackendEnabled) as exc:
-        logger.exception(
+        logger.info(
             '[send_event] Failed to send event [%s] with backend [%s], [%s]',
             processed_event['name'], backend_name, exc
         )
@@ -46,6 +48,6 @@ def send_event(self, backend_name, processed_event):
     except Exception as exc:
         logger.exception(
             '[send_event] Failed to send event [%s] with backend [%s], [%s]',
-            processed_event['name'], backend_name, exc
+            processed_event['name'], backend_name, repr(exc)
         )
         raise self.retry(exc=exc, countdown=COUNTDOWN, max_retries=MAX_RETRIES)

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ REQUIREMENTS = load_requirements('requirements/base.in')
 
 setup(
     name='event-tracking',
-    version='1.1.1',
+    version='1.1.2',
     packages=find_packages(),
     include_package_data=True,
     license='AGPLv3 License',


### PR DESCRIPTION
Incase we have disabled either caliper or xapi backends or we have not defined any transformer for certain events it makes sense to log such exceptions as `info` instead of `exception`.